### PR TITLE
Fix document of In

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Moreover, instances of the following types are converted to callables on the com
 
     Schema({
         # These two keys should have integer values
-        In('age', 'height'): int,
+        In(('age', 'height')): int,
         # All other keys should have string values
         str: str,
     })({

--- a/README.rst
+++ b/README.rst
@@ -349,7 +349,7 @@ the compilation phase:
 
        Schema({
            # These two keys should have integer values
-           In('age', 'height'): int,
+           In(('age', 'height')): int,
            # All other keys should have string values
            str: str,
        })({


### PR DESCRIPTION
This code is from current README.

```
from good import Schema, In

Schema({
    # These two keys should have integer values
    In('age', 'height'): int,
    # All other keys should have string values
    str: str,
})({
    'age': 18,
    'height': 173,
    'name': 'Alex',
})
```

However I got this error.

```
% python foo.py
Traceback (most recent call last):
  File "foo.py", line 8, in <module>
    })({
TypeError: __init__() takes 2 positional arguments but 3 were given
```

I think the code is bit wrong.
