### PR TITLE
Add a NotEmpty convenience string validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Table of Contents
         * <a href="#upper">Upper</a>
         * <a href="#capitalize">Capitalize</a>
         * <a href="#title">Title</a>
+        * <a href="#notempty">NotEmpty</a>
         * <a href="#match">Match</a>
         * <a href="#replace">Replace</a>
         * <a href="#url">Url</a>
@@ -1967,6 +1968,34 @@ Title()
 
 Casts The Input String To Title Case
 
+
+
+
+
+
+### `NotEmpty`
+```python
+NotEmpty(message=None)
+```
+
+Checks that the string is not empty.
+
+```python
+from good import Schema, NotEmpty
+
+schema = Schema(All(
+    unicode,
+    NotEmpty()
+))
+
+schema('Hello, world')  #-> 'Hello, world'
+schema('')
+#-> Invalid: Can't be empty
+```
+
+Arguments:
+
+* `message`: Error message override
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,7 @@ Table of Contents
       -  Upper
       -  Capitalize
       -  Title
+      -  NotEmpty
       -  Match
       -  Replace
       -  Url
@@ -2016,6 +2017,32 @@ Capitalizes the input string.
     Title()
 
 Casts The Input String To Title Case
+
+``NotEmpty``
+~~~~~~~~~~~~
+
+.. code:: python
+
+    NotEmpty(message=None)
+
+Checks that the string is not empty.
+
+.. code:: python
+
+    from good import Schema, NotEmpty
+
+    schema = Schema(All(
+        unicode,
+        NotEmpty()
+    ))
+
+    schema('Hello, world')  #-> 'Hello, world'
+    schema('')
+    #-> Invalid: Can't be empty
+
+Arguments:
+
+-  ``message``: Error message override
 
 ``Match``
 ~~~~~~~~~

--- a/good/validators/strings.py
+++ b/good/validators/strings.py
@@ -58,6 +58,43 @@ def Title():
     return 'title'
 
 
+class NotEmpty(ValidatorBase):
+    """ Checks that the string is not empty.
+
+    ```python
+    from good import Schema, NotEmpty
+
+    schema = Schema(All(
+        unicode,
+        NotEmpty()
+    ))
+
+    schema('Hello, world')  #-> 'Hello, world'
+    schema('')
+    #-> Invalid: Can't be empty
+    ```
+
+    :param message: Error message override
+    :type message: unicode
+    """
+
+    name = u'not empty'
+
+    def __init__(self, message=None):
+        self.message = message or _(u'Can\'t be empty')
+
+    def __call__(self, v):
+        # Is a string?
+        if not isinstance(v, six.string_types):
+            raise Invalid(_(u'Not a string'), get_type_name(six.text_type), get_type_name(type(v)))
+
+        # Empty?
+        if not len(v):
+            raise Invalid(self.message, expected=None, provided=v)
+
+        return v
+
+
 class Match(ValidatorBase):
     """ Validate the input string against a regular expression.
 
@@ -255,4 +292,4 @@ class Email(Match):
         super(Email, self).__init__(self._rex, u'Invalid E-Mail', u'E-Mail')
 
 
-__all__ = ('Lower', 'Upper', 'Capitalize', 'Title', 'Match', 'Replace', 'Url', 'Email')
+__all__ = ('Lower', 'Upper', 'Capitalize', 'Title', 'NotEmpty', 'Match', 'Replace', 'Url', 'Email')

--- a/misc/_doc/README.md.j2
+++ b/misc/_doc/README.md.j2
@@ -84,6 +84,7 @@ Table of Contents
         * <a href="#upper">Upper</a>
         * <a href="#capitalize">Capitalize</a>
         * <a href="#title">Title</a>
+        * <a href="#notempty">NotEmpty</a>
         * <a href="#match">Match</a>
         * <a href="#replace">Replace</a>
         * <a href="#url">Url</a>

--- a/tests/schema-test.py
+++ b/tests/schema-test.py
@@ -1352,6 +1352,20 @@ class StringsTest(GoodTestBase):
         schema = Schema(Title())
         self.assertValid(schema, u'abc def', u'Abc Def')
 
+    def test_NotEmpty(self):
+        """ Test NotEmpty() """
+
+        not_empty = NotEmpty()
+        schema = Schema(not_empty)
+
+        self.assertValid(schema, u'Hello, world')
+        self.assertValid(schema, u' ')
+
+        self.assertInvalid(schema, u'',
+                           Invalid(u'Can\'t be empty', u'not empty', u'', None, not_empty))
+        self.assertInvalid(schema, 123,
+                           Invalid(u'Not a string', u'String', s.t_int, [], not_empty))
+
     def test_Match(self):
         """ Test Match() """
 


### PR DESCRIPTION
Although this can be accomplished with the Length validator, a specific empty string validator is desirable for a more fluent error message and API.